### PR TITLE
Fixes `SetSpawnCameraLookAtEx` not working as intended

### DIFF
--- a/module/Misc/Functions.cpp
+++ b/module/Misc/Functions.cpp
@@ -762,7 +762,7 @@ void SetSpawnCameraPositionEx(float x, float y, float z)
 // ------------------------------------------------------------------------------------------------
 void SetSpawnCameraLookAtEx(float x, float y, float z)
 {
-    _Func->SetSpawnPlayerPosition(x, y, z);
+    _Func->SetSpawnCameraLookAt(x, y, z);
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
`SetSpawnCameraLookAtEx` was basically the same as `SetSpawnPlayerPositionEx`